### PR TITLE
add saving hyperparameters and dataset reference

### DIFF
--- a/lightning_toolbox/data/module.py
+++ b/lightning_toolbox/data/module.py
@@ -104,7 +104,10 @@ class DataModule(lightning.LightningDataModule):
         self.train_num_workers = train_num_workers if train_num_workers is not None else num_workers
         self.val_num_workers = val_num_workers if val_num_workers is not None else num_workers
         self.test_num_workers = test_num_workers if test_num_workers is not None else num_workers
-
+        
+        # Save all the hyper parameters for further reference:
+        self.save_hyperparameters()
+        
     @staticmethod
     def get_dataset(dataset: th.Union[str, Dataset], **params):
         assert isinstance(
@@ -135,6 +138,9 @@ class DataModule(lightning.LightningDataModule):
             self.train_dataset,
             **self.train_dataset_args,
         )
+        # Also save the dataset for later use
+        self.dataset = dataset
+        
         if not self.val_size:
             # setup train data (in case validation is not to be a subset of provided dataset with val_size)
             self.train_data = dataset

--- a/lightning_toolbox/objective_function/objective.py
+++ b/lightning_toolbox/objective_function/objective.py
@@ -62,14 +62,16 @@ class Objective:
         *term_args: TermDescriptor,
         **term_kwargs: TermDescriptor,
     ) -> None:
-        term_args = [ObjectiveTerm.from_description(term, objective=self) for term in term_args]
+        term_args = [ObjectiveTerm.from_description(
+            term, objective=self) for term in term_args]
         term_kwargs = [
             ObjectiveTerm.from_description(term, objective=self, name=name) for name, term in term_kwargs.items()
         ]
         self.terms: th.List[ObjectiveTerm] = term_args + term_kwargs
-        self.__rename_terms(terms=self.terms)  # to make sure all terms have unique names
+        # to make sure all terms have unique names
+        self.__rename_terms(terms=self.terms)
         # initialize the latches
-        self.latch, self.results_latch, self.factors_latch = {}, {}, {}
+        self.inputs_latch, self.latch, self.results_latch, self.factors_latch = {}, {}, {}, {}
 
     @property
     def results(self) -> ResultsDict:
@@ -133,14 +135,16 @@ class Objective:
             *args, **kwargs: the arguments passed to the objective are directly passed to the terms.
         """
         if len(self.terms) == 0:
-            warnings.warn("No terms provided to the objective. Undefined behaviour might occur", RuntimeWarning)
+            warnings.warn(
+                "No terms provided to the objective. Undefined behaviour might occur", RuntimeWarning)
 
         for term in self.terms:
             term_results = term(*args, **kwargs)
             if isinstance(term_results, dict):
                 for name in term_results:
                     # for loss, use the term name since it is the overall term value and should be reduced together with other terms
-                    self.results_latch[f"{term.name}/{name}" if name != "loss" else term.name] = term_results[name]
+                    self.results_latch[f"{term.name}/{name}" if name !=
+                                       "loss" else term.name] = term_results[name]
             else:
                 self.results_latch[term.name] = term_results
 
@@ -156,9 +160,11 @@ class Objective:
             The reduced loss/objective value.
         """
         factors_applied_values = [
-            term.apply_factor(term_value=self.results_latch[term.name], factor_value=self.factors_latch[term.name])
+            term.apply_factor(
+                term_value=self.results_latch[term.name], factor_value=self.factors_latch[term.name])
             for term in self.terms
-            if term.name in self.results_latch  # only reduce terms that contribute to the loss
+            # only reduce terms that contribute to the loss
+            if term.name in self.results_latch
         ]
         return sum(factors_applied_values)
 
@@ -166,9 +172,16 @@ class Objective:
         self, *args, return_factors: bool = False, **kwargs
     ) -> th.Union[ResultsDict, th.Tuple[ResultsDict, FactorsDict]]:
         self._forget()  # clear the latches
+
+        # Save all the input arguments in the latch
+        self.inputs_latch.update(kwargs)
+
         self.process_terms_results(*args, **kwargs)  # process the terms
         self.factors_latch = {
             term.name: term.factor(*args, **kwargs) for term in self.terms if term.name in self.results_latch
         }  # compute the factor values for the terms that contribute to the loss
-        self.results_latch["loss"] = self.reduce()  # reduce the term results with the factors
+
+        # Save all the results in the latch
+        # reduce the term results with the factors
+        self.results_latch["loss"] = self.reduce()
         return self.results_latch if not return_factors else (self.results_latch, self.factors_latch)

--- a/lightning_toolbox/objective_function/objective.py
+++ b/lightning_toolbox/objective_function/objective.py
@@ -62,8 +62,7 @@ class Objective:
         *term_args: TermDescriptor,
         **term_kwargs: TermDescriptor,
     ) -> None:
-        term_args = [ObjectiveTerm.from_description(
-            term, objective=self) for term in term_args]
+        term_args = [ObjectiveTerm.from_description(term, objective=self) for term in term_args]
         term_kwargs = [
             ObjectiveTerm.from_description(term, objective=self, name=name) for name, term in term_kwargs.items()
         ]
@@ -135,16 +134,14 @@ class Objective:
             *args, **kwargs: the arguments passed to the objective are directly passed to the terms.
         """
         if len(self.terms) == 0:
-            warnings.warn(
-                "No terms provided to the objective. Undefined behaviour might occur", RuntimeWarning)
+            warnings.warn("No terms provided to the objective. Undefined behaviour might occur", RuntimeWarning)
 
         for term in self.terms:
             term_results = term(*args, **kwargs)
             if isinstance(term_results, dict):
                 for name in term_results:
                     # for loss, use the term name since it is the overall term value and should be reduced together with other terms
-                    self.results_latch[f"{term.name}/{name}" if name !=
-                                       "loss" else term.name] = term_results[name]
+                    self.results_latch[f"{term.name}/{name}" if name != "loss" else term.name] = term_results[name]
             else:
                 self.results_latch[term.name] = term_results
 
@@ -160,8 +157,7 @@ class Objective:
             The reduced loss/objective value.
         """
         factors_applied_values = [
-            term.apply_factor(
-                term_value=self.results_latch[term.name], factor_value=self.factors_latch[term.name])
+            term.apply_factor(term_value=self.results_latch[term.name], factor_value=self.factors_latch[term.name])
             for term in self.terms
             # only reduce terms that contribute to the loss
             if term.name in self.results_latch

--- a/lightning_toolbox/training/module.py
+++ b/lightning_toolbox/training/module.py
@@ -34,12 +34,9 @@ class TrainingModule(lightning.LightningModule):
         objective_args: th.Optional[dict] = None,
         # optimization configs
         # optimizer name or class
-        optimizer: th.Union[str, type,
-                            th.List[th.Union[str, type]], None] = None,
-        optimizer_frequency: th.Union[int,
-                                      th.List[th.Optional[int]], None] = None,
-        optimizer_is_active: th.Optional[th.Union[dy.FunctionDescriptor,
-                                                  th.List[dy.FunctionDescriptor]]] = None,
+        optimizer: th.Union[str, type, th.List[th.Union[str, type]], None] = None,
+        optimizer_frequency: th.Union[int, th.List[th.Optional[int]], None] = None,
+        optimizer_is_active: th.Optional[th.Union[dy.FunctionDescriptor, th.List[dy.FunctionDescriptor]]] = None,
         # optimizer parameters (self.<*>)
         optimizer_parameters: th.Optional[th.Union[th.List[str], str]] = None,
         optimizer_args: th.Optional[dict] = None,
@@ -47,8 +44,7 @@ class TrainingModule(lightning.LightningModule):
         lr: th.Union[th.List[float], float] = 1e-4,
         # schedulers
         # scheduler name or class
-        scheduler: th.Optional[th.Union[str, type,
-                                        th.List[th.Union[str, type]]]] = None,
+        scheduler: th.Optional[th.Union[str, type, th.List[th.Union[str, type]]]] = None,
         scheduler_name: th.Optional[th.Union[str, th.List[str]]] = None,
         # optimizer index
         scheduler_optimizer: th.Optional[th.Union[int, th.List[int]]] = None,
@@ -69,8 +65,7 @@ class TrainingModule(lightning.LightningModule):
         # objective
         if objective is not None or objective_cls is not None:
             self.objective = (
-                objective if objective is not None else dy.eval(
-                    objective_cls)(**(objective_args or dict()))
+                objective if objective is not None else dy.eval(objective_cls)(**(objective_args or dict()))
             )
 
         # optimizers
@@ -81,8 +76,7 @@ class TrainingModule(lightning.LightningModule):
             args=optimizer_args,
             frequency=optimizer_frequency,
         )
-        self.optimizers_list = None if self.optimizers_list[
-            "optimizer"] is None else self.optimizers_list
+        self.optimizers_list = None if self.optimizers_list["optimizer"] is None else self.optimizers_list
 
         # learning rate
         self.lr = lr  # populate when configure_optimizers is called
@@ -98,14 +92,12 @@ class TrainingModule(lightning.LightningModule):
             monitor=scheduler_monitor,
             strict=scheduler_strict,
         )
-        self.schedulers_list = None if self.schedulers_list.value(
-            0, "scheduler") is None else self.schedulers_list
+        self.schedulers_list = None if self.schedulers_list.value(0, "scheduler") is None else self.schedulers_list
 
         # cross-populate schedulers (if we have schedulers) if scheduler descriptions have no optimizer specified
         if self.schedulers_list is not None and all(sched["optimizer"] is None for sched in self.schedulers_list):
             # cross-populating schedulers repeats the same scheduler description for each optimizer
-            schedulers_list = self.schedulers_list.cross_populate(
-                length=self.optimizers_list.args_length)
+            schedulers_list = self.schedulers_list.cross_populate(length=self.optimizers_list.args_length)
             # set scheduler optimizers
             schedulers_list["optimizer"] = [
                 i for j in range(self.schedulers_list.args_length) for i in range(self.optimizers_list.args_length)
@@ -120,11 +112,9 @@ class TrainingModule(lightning.LightningModule):
                 else ([self.schedulers_list["name"]] * self.schedulers_list.args_length)
             )
             for idx, sched in enumerate(self.schedulers_list):
-                param_name = self.optimizers_list.value(
-                    sched["optimizer"], "parameters")
+                param_name = self.optimizers_list.value(sched["optimizer"], "parameters")
                 param_name = (
-                    f"/{param_name}" if param_name and isinstance(
-                        param_name, str) else f"/{sched['optimizer']}"
+                    f"/{param_name}" if param_name and isinstance(param_name, str) else f"/{sched['optimizer']}"
                 )
                 self.schedulers_list["name"][
                     idx
@@ -132,8 +122,7 @@ class TrainingModule(lightning.LightningModule):
 
         # initialize the model
         if model is not None or model_args is not None or model_cls is not None:
-            self.model = model if model is not None else dy.eval(
-                model_cls)(**(model_args or dict()))
+            self.model = model if model is not None else dy.eval(model_cls)(**(model_args or dict()))
 
     @functools.cached_property
     def __optimizers_is_active_list(self):
@@ -142,8 +131,7 @@ class TrainingModule(lightning.LightningModule):
         if self.optimizers_list["is_active"] is None:
             return [True for i in range(len(self.optimizers_list["optimizer"]))]
         return [
-            dy.eval(optimizer["is_active"], function_of_interest="is_active",
-                    dynamic_args=True, strict=False)
+            dy.eval(optimizer["is_active"], function_of_interest="is_active", dynamic_args=True, strict=False)
             for optimizer in self.optimizers_list
         ]
 
@@ -151,11 +139,9 @@ class TrainingModule(lightning.LightningModule):
         if optimizer_idx is None:
             return True
         is_active = self.__optimizers_is_active_list[optimizer_idx]
-        result = is_active is None or (
-            isinstance(is_active, bool) and is_active)
+        result = is_active is None or (isinstance(is_active, bool) and is_active)
         if callable(is_active):
-            result = is_active(
-                training_module=self, optimizer_idx=optimizer_idx, batch_idx=batch_idx, epoch=epoch)
+            result = is_active(training_module=self, optimizer_idx=optimizer_idx, batch_idx=batch_idx, epoch=epoch)
         return result
 
     def remember(self, **kwargs: th.Dict[str, th.Any]) -> None:
@@ -229,16 +215,13 @@ class TrainingModule(lightning.LightningModule):
             return
         optimizers, schedulers = [], []
         # populate learning rates for each optimizer
-        learning_rates = [i["lr"] for i in ArgsListDict(
-            lr=self.lr, length=self.optimizers_list.args_length)]
+        learning_rates = [i["lr"] for i in ArgsListDict(lr=self.lr, length=self.optimizers_list.args_length)]
 
         # initialize the optimizers
         optimizers_using_frequency = False
         for optimizer, lr in zip(self.optimizers_list, learning_rates):
-            opt_args = {
-                "lr": lr, **(optimizer["args"] if optimizer["args"] is not None else {})}
-            params = dy.eval(
-                optimizer["parameters"], context=self) if optimizer["parameters"] else self
+            opt_args = {"lr": lr, **(optimizer["args"] if optimizer["args"] is not None else {})}
+            params = dy.eval(optimizer["parameters"], context=self) if optimizer["parameters"] else self
             if isinstance(params, torch.Tensor):
                 params = [params]
             else:
@@ -254,8 +237,7 @@ class TrainingModule(lightning.LightningModule):
                 optimizers.append(opt)
             else:
                 optimizers_using_frequency = True
-                optimizers.append(
-                    dict(optimizer=opt, frequency=optimizer["frequency"]))
+                optimizers.append(dict(optimizer=opt, frequency=optimizer["frequency"]))
 
         for sched in self.schedulers_list or []:
             optim = optimizers[sched["optimizer"]]
@@ -275,11 +257,9 @@ class TrainingModule(lightning.LightningModule):
                     raise ValueError(
                         "you cannot have multiple schedulers for the same optimizer, when using optimizer frequency "
                     )  # TODO: use pytorch's ChainedScheduler to chain multiple non-conflicting schedulers
-                optim["lr_scheduler"] = dict(
-                    scheduler=scheduler, **instance) if instance else scheduler
+                optim["lr_scheduler"] = dict(scheduler=scheduler, **instance) if instance else scheduler
             else:
-                schedulers.append(
-                    dict(scheduler=scheduler, **instance) if instance else scheduler)
+                schedulers.append(dict(scheduler=scheduler, **instance) if instance else scheduler)
 
         if schedulers:
             if len(schedulers) == 1 and len(optimizers) == 1:

--- a/lightning_toolbox/training/module.py
+++ b/lightning_toolbox/training/module.py
@@ -33,17 +33,21 @@ class TrainingModule(lightning.LightningModule):
         objective_cls: th.Union[type, str] = "lightning_toolbox.Objective",
         objective_args: th.Optional[dict] = None,
         # optimization configs
-        optimizer: th.Union[str, type, th.List[th.Union[str, type]], None] = None,  # optimizer name or class
+        # optimizer name or class
+        optimizer: th.Union[str, type, th.List[th.Union[str, type]], None] = None,
         optimizer_frequency: th.Union[int, th.List[th.Optional[int]], None] = None,
         optimizer_is_active: th.Optional[th.Union[dy.FunctionDescriptor, th.List[dy.FunctionDescriptor]]] = None,
-        optimizer_parameters: th.Optional[th.Union[th.List[str], str]] = None,  # optimizer parameters (self.<*>)
+        # optimizer parameters (self.<*>)
+        optimizer_parameters: th.Optional[th.Union[th.List[str], str]] = None,
         optimizer_args: th.Optional[dict] = None,
         # learning rate
         lr: th.Union[th.List[float], float] = 1e-4,
         # schedulers
-        scheduler: th.Optional[th.Union[str, type, th.List[th.Union[str, type]]]] = None,  # scheduler name or class
+        # scheduler name or class
+        scheduler: th.Optional[th.Union[str, type, th.List[th.Union[str, type]]]] = None,
         scheduler_name: th.Optional[th.Union[str, th.List[str]]] = None,
-        scheduler_optimizer: th.Optional[th.Union[int, th.List[int]]] = None,  # optimizer index
+        # optimizer index
+        scheduler_optimizer: th.Optional[th.Union[int, th.List[int]]] = None,
         scheduler_args: th.Optional[th.Union[dict, th.List[dict]]] = None,
         scheduler_interval: th.Union[str, th.List[str]] = "epoch",
         scheduler_frequency: th.Union[int, th.List[int]] = 1,
@@ -140,10 +144,23 @@ class TrainingModule(lightning.LightningModule):
             result = is_active(training_module=self, optimizer_idx=optimizer_idx, batch_idx=batch_idx, epoch=epoch)
         return result
 
+    def remember(self, **kwargs: th.Dict[str, th.Any]) -> None:
+        """
+        You can use this function to remember any particular object that you want to
+        use later on.
+
+        **Note**: The values that are remembered will be forgotten soon after every batch
+        so make sure to save them in another logging mechanism if you want to keep them.
+        Typically, this is implemented using a LoggingCallback.
+        """
+        self.objective.remember(**kwargs)
+
     def forward(self, inputs):
         "Placeholder forward pass for the model"
         if hasattr(self, "model") and self.model is not None:
-            return self.model(inputs)
+            # Also pass the training module to the model so that it can access the objective
+            # or any other attribute of the training module that might be needed
+            return self.model(inputs, training_module=self)
         raise NotImplementedError("No model defined")
 
     def step(


### PR DESCRIPTION
I have added pieces of code that:

1. enables accessing the inner dataset from the datamodule:
This can come in handy when you want to print out something from the inner dataset after the .setup("fit") phase

2. enables accessing the datamodule configurations by simply calling `.save_hyperparameters()`. That way, one can save the data configurations in the configuration of any logger later on.

3. Enables custom latching capabilities by passing the training_module to the forward of the torch.nn.Module: This is currently used in the OCD project so I would appreciate it if you keep the syntax I created.